### PR TITLE
Promise 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,9 @@ import { JwtModule } from '@nestjs/jwt';
 import { APP_GUARD } from '@nestjs/core';
 import { JwtGuard } from './common/guard/jwt-guard';
 import { EnvKeys } from './common/enum/env-keys';
+import { PromiseModule } from './promise/promise.module';
+import { User } from './user/entity/user.entity';
+import { Promise } from './promise/entity/promise.entity';
 
 @Module({
   imports: [
@@ -33,13 +36,14 @@ import { EnvKeys } from './common/enum/env-keys';
         username: configService.get(EnvKeys.DB_USERNAME),
         password: configService.get(EnvKeys.DB_PASSWORD),
         database: configService.get(EnvKeys.DB_DATABASE),
-        autoLoadEntities: true,
+        entities: [User, Promise],
         synchronize: true,
       }),
     }),
     JwtModule.register({ global: true }),
     AuthModule,
     UserModule,
+    PromiseModule,
   ],
   controllers: [],
   providers: [

--- a/src/common/enum/promise-state.ts
+++ b/src/common/enum/promise-state.ts
@@ -1,0 +1,5 @@
+export enum PromiseState {
+  NotCompleted,
+  Completed,
+  Skip,
+}

--- a/src/promise/dto/create-promise.dto.ts
+++ b/src/promise/dto/create-promise.dto.ts
@@ -1,0 +1,1 @@
+export class CreatePromiseDto {}

--- a/src/promise/dto/update-promise.dto.ts
+++ b/src/promise/dto/update-promise.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreatePromiseDto } from './create-promise.dto';
+
+export class UpdatePromiseDto extends PartialType(CreatePromiseDto) {}

--- a/src/promise/entity/promise.entity.ts
+++ b/src/promise/entity/promise.entity.ts
@@ -1,0 +1,25 @@
+import { PromiseState } from 'src/common/enum/promise-state';
+import { User } from 'src/user/entity/user.entity';
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity('promise')
+export class Promise {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ nullable: false })
+  title: string;
+
+  @Column({ comment: 'Number Array를 String으로 저장', nullable: false })
+  dayOfWeek: string;
+
+  @Column({
+    type: 'enum',
+    enum: PromiseState,
+    default: PromiseState.NotCompleted,
+  })
+  promiseState: PromiseState;
+
+  @ManyToOne(() => User, (user) => user.promises)
+  user: User;
+}

--- a/src/promise/promise.controller.ts
+++ b/src/promise/promise.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { PromiseService } from './promise.service';
+
+@Controller('promise')
+export class PromiseController {
+  constructor(private readonly promiseService: PromiseService) {}
+}

--- a/src/promise/promise.module.ts
+++ b/src/promise/promise.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PromiseService } from './promise.service';
+import { PromiseController } from './promise.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Promise])],
+  controllers: [PromiseController],
+  providers: [PromiseService],
+})
+export class PromiseModule {}

--- a/src/promise/promise.service.ts
+++ b/src/promise/promise.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class PromiseService {}

--- a/src/user/entity/user.entity.ts
+++ b/src/user/entity/user.entity.ts
@@ -1,5 +1,6 @@
 import { ROLE } from 'src/common/enum/role';
-import { Column, CreateDateColumn, Entity, PrimaryColumn } from 'typeorm';
+import { Promise } from 'src/promise/entity/promise.entity';
+import { Column, CreateDateColumn, Entity, OneToMany, PrimaryColumn } from 'typeorm';
 
 @Entity('user')
 export class User {
@@ -40,4 +41,7 @@ export class User {
 
   @CreateDateColumn()
   createdAt: Date;
+
+  @OneToMany(() => Promise, (promise) => promise.user)
+  promises: Promise[]
 }


### PR DESCRIPTION
- **feat(promise): 약속 기능을 위한 엔티티 및 DTO 추가 약속 상태를 정의하는 PromiseState 열거형을 추가하고, CreatePromiseDto 및 UpdatePromiseDto 클래스를 생성하여 약속 생성 및 업데이트를 위한 데이터 전송 객체를 정의한다. Promise 엔티티를 추가하여 데이터베이스와의 상호작용을 지원하며, PromiseController 및 PromiseService를 통해 약속 관련 API를 구현한다.**
- **feat(user.entity.ts): User 엔티티에 promises 필드 추가 User와 Promise 간의 일대다 관계를 정의하여 데이터 모델을 확장**
- **feat(app.module.ts): PromiseModule 및 엔티티 추가 PromiseModule을 앱 모듈에 통합하고 User 및 Promise 엔티티를 명시하여 데이터베이스와의 상호작용을 개선한다.**
