### PR TITLE
Promise 업데이트 기능 추가

### DIFF
--- a/src/exception/custom-exception/is-not-uuid.exception.ts
+++ b/src/exception/custom-exception/is-not-uuid.exception.ts
@@ -1,0 +1,8 @@
+import { HttpStatus } from '@nestjs/common';
+import { HttpException } from '../http.exception';
+
+export class IsNotUUidException extends HttpException {
+  constructor() {
+    super('아이디 형식이 UUID가 아닙니다.', HttpStatus.BAD_REQUEST);
+  }
+}

--- a/src/exception/custom-exception/promise-not-found.exception.ts
+++ b/src/exception/custom-exception/promise-not-found.exception.ts
@@ -1,0 +1,8 @@
+import { HttpStatus } from "@nestjs/common";
+import { HttpException } from "../http.exception";
+
+export class PromiseNotFoundException extends HttpException {
+    constructor(){
+        super("해당하는 ID의 약속이 아닙니다.", HttpStatus.NOT_FOUND)
+    }
+}

--- a/src/promise/dto/request/update-promise.request.ts
+++ b/src/promise/dto/request/update-promise.request.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreatePromiseRequest } from './create-promise.request';
+
+export class UpdatePromiseRequest extends PartialType(CreatePromiseRequest) {}

--- a/src/promise/promise.controller.ts
+++ b/src/promise/promise.controller.ts
@@ -1,8 +1,10 @@
-import { Body, Controller, Get, Post, Query } from '@nestjs/common';
+import { Body, Controller, Get, Param, ParseUUIDPipe, Patch, Post, Query } from '@nestjs/common';
 import { PromiseService } from './promise.service';
 import { CreatePromiseRequest } from './dto/request/create-promise.request';
 import { GetUserEmail } from 'src/common/decorator/get-user';
 import { GetPromsieRequest } from './dto/request/get-promise.request';
+import { UpdatePromiseRequest } from './dto/request/update-promise.request';
+import { IsNotUUidException } from 'src/exception/custom-exception/is-not-uuid.exception';
 
 @Controller('promise')
 export class PromiseController {
@@ -11,16 +13,29 @@ export class PromiseController {
   @Post()
   createPromise(
     @GetUserEmail() userEmail: string,
-    @Body() createPromise: CreatePromiseRequest,
+    @Body() createPromiseRequest: CreatePromiseRequest,
   ) {
-    return this.promiseService.createPromise(userEmail, createPromise);
+    return this.promiseService.createPromise(userEmail, createPromiseRequest);
+  }
+
+  @Patch('/:id')
+  updatePromise(
+    @Param('id', new ParseUUIDPipe({
+      exceptionFactory(errors) {
+        throw new IsNotUUidException()
+      },
+    })) id: string,
+    @GetUserEmail() userEmail: string,
+    @Body() updatePromiseRequest: UpdatePromiseRequest,
+  ) {
+    return this.promiseService.updatePromise(id, userEmail, updatePromiseRequest);
   }
 
   @Get()
   getPromises(
     @GetUserEmail() userEmail: string,
-    @Query() getPromise: GetPromsieRequest,
+    @Query() getPromsieRequest: GetPromsieRequest,
   ) {
-    return this.promiseService.getPromises(userEmail, getPromise);
+    return this.promiseService.getPromises(userEmail, getPromsieRequest);
   }
 }


### PR DESCRIPTION
- **feat(exception): UUID 형식 오류 및 약속 미발견 예외 추가 아이디 형식이 UUID가 아닐 때와 약속이 존재하지 않을 때의 예외 처리를 위해 새로운 예외 클래스를 추가.**
- **feat(update-promise.request.ts): UpdatePromiseRequest 클래스 추가 새로운 요청 DTO를 통해 Promise 업데이트 기능을 지원하기 위함.**
- **feat(promise): 약속 업데이트 기능 추가 및 예외 처리 개선 - PATCH 메서드를 사용하여 약속을 업데이트하는 기능을 추가 - UUID 파라미터 검증을 위한 ParseUUIDPipe 사용 - 업데이트 요청 DTO 추가 및 서비스 로직 구현 - 약속이 존재하지 않을 경우 예외 처리 추가**
