### PR TITLE
Promise CreatedAt 추가

### DIFF
--- a/src/common/interface/promise.interface.ts
+++ b/src/common/interface/promise.interface.ts
@@ -4,4 +4,5 @@ export interface Promise {
   title: string;
   dayOfWeek: number[];
   promiseState: PromiseState;
+  createdAt: Date;
 }

--- a/src/promise/dto/request/create-promise.request.ts
+++ b/src/promise/dto/request/create-promise.request.ts
@@ -1,3 +1,4 @@
+import { Transform } from 'class-transformer';
 import { IsNotEmpty, IsNumber, IsString, Max, Min } from 'class-validator';
 
 export class CreatePromiseRequest {
@@ -9,5 +10,6 @@ export class CreatePromiseRequest {
   @IsNumber({}, { each: true, message: 'List는 숫자로만 이루어져야 합니다.' })
   @Min(0, { each: true, message: '0~6 내외의 숫자만을 리스트에 넣어주세요' })
   @Max(6, { each: true, message: '0~6 내외의 숫자만을 리스트에 넣어주세요' })
+  @Transform(({ value }) => value.sort())
   dayOfWeek: number[];
 }

--- a/src/promise/dto/response/get-promises.response.ts
+++ b/src/promise/dto/response/get-promises.response.ts
@@ -12,6 +12,7 @@ export class GetPromisesResponse {
           ? value.dayOfWeek.split(',').map((value) => Number(value))
           : null,
         promiseState: value.promiseState,
+        createdAt: value.createdAt,
       };
     });
   }

--- a/src/promise/entity/promise.entity.ts
+++ b/src/promise/entity/promise.entity.ts
@@ -1,6 +1,6 @@
 import { PromiseState } from 'src/common/enum/promise-state';
 import { User } from 'src/user/entity/user.entity';
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { AfterLoad, Column, CreateDateColumn, Entity, Index, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity('promise')
 export class Promise {
@@ -22,4 +22,7 @@ export class Promise {
 
   @ManyToOne(() => User, (user) => user.promises)
   user: User;
+
+  @CreateDateColumn({ type: "timestamp" })
+  createdAt: Date;
 }

--- a/src/promise/promise.service.ts
+++ b/src/promise/promise.service.ts
@@ -62,7 +62,7 @@ export class PromiseService {
         .take(takeNumber)
         .where('p.userEmail = :userEmail', { userEmail });
 
-      if(dayOfWeek) {
+      if (dayOfWeek) {
         dayOfWeek.forEach((day, index) => {
           query.andWhere(`FIND_IN_SET(:day, p.dayOfWeek)`, {
             day,
@@ -70,7 +70,11 @@ export class PromiseService {
         });
       }
 
-      return new GetPromisesResponse(await query.getMany());
+      query.orderBy('p.createdAt', 'DESC')
+
+      return new GetPromisesResponse(
+        await query.getMany()
+      );
     } catch (error) {
       throw new ServerException();
     }


### PR DESCRIPTION
- **feat(promise.entity.ts): Promise 엔티티에 createdAt 필드 추가 Promise 생성 시 타임스탬프를 기록하기 위해 createdAt 필드를 추가**
- **feat(promise.interface.ts): Promise 인터페이스에 createdAt 속성 추가 새로운 createdAt 속성을 추가하여 약속 생성 시간을 기록한다.**
- **feat(get-promises.response.ts): 응답 DTO에 createdAt 필드 추가 응답에 생성 날짜 정보를 포함하여 클라이언트에 제공하기 위함.**
- **style(promise.service.ts): 코드 스타일 개선을 위한 공백 추가 및 정렬 feat(promise.service.ts): 쿼리 결과를 생성일 기준으로 내림차순 정렬 추가**
- **feat(create-promise.request.ts): dayOfWeek 배열 정렬을 위한 Transform 추가 dayOfWeek 속성에 입력된 숫자 배열을 정렬하여 유효성을 높임.**
