### PR TITLE
chatEntity 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { PromiseModule } from './promise/promise.module';
 import { User } from './user/entity/user.entity';
 import { Promise } from './promise/entity/promise.entity';
 import { ChatModule } from './chat/chat.module';
+import { Chat } from './chat/entity/chat.entity';
 
 @Module({
   imports: [
@@ -38,7 +39,7 @@ import { ChatModule } from './chat/chat.module';
         username: configService.get(EnvKeys.DB_USERNAME),
         password: configService.get(EnvKeys.DB_PASSWORD),
         database: configService.get(EnvKeys.DB_DATABASE),
-        entities: [User, Promise],
+        entities: [User, Promise, Chat],
         synchronize: true,
       }),
     }),

--- a/src/chat/entity/chat.entity.ts
+++ b/src/chat/entity/chat.entity.ts
@@ -1,0 +1,36 @@
+import { ROLE } from 'src/common/enum/role';
+import { Promise } from 'src/promise/entity/promise.entity';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+@Entity('chat')
+@Index(['promise'])
+export class Chat {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => Promise, (promise) => promise.chates, { nullable: false })
+  promise: Promise;
+
+  @Column({
+    type: 'enum',
+    enum: ROLE,
+    nullable: false,
+  })
+  role: ROLE;
+
+  @Column({
+    type: 'text',
+    nullable: false,
+  })
+  content: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/promise/entity/promise.entity.ts
+++ b/src/promise/entity/promise.entity.ts
@@ -1,6 +1,7 @@
+import { Chat } from 'src/chat/entity/chat.entity';
 import { PromiseState } from 'src/common/enum/promise-state';
 import { User } from 'src/user/entity/user.entity';
-import { AfterLoad, Column, CreateDateColumn, Entity, Index, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, CreateDateColumn, Entity, Index, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity('promise')
 export class Promise {
@@ -22,6 +23,9 @@ export class Promise {
 
   @ManyToOne(() => User, (user) => user.promises)
   user: User;
+
+  @OneToMany(() => Chat, (chat) => chat.promise)
+  chates: Chat;
 
   @CreateDateColumn({ type: "timestamp" })
   createdAt: Date;


### PR DESCRIPTION
- **feat(chat.entity.ts): 채팅 엔티티 추가 및 역할과 내용 필드 정의 feat(promise.entity.ts): Promise 엔티티에 채팅과의 관계 추가**
- **feat(app.module.ts): Chat 엔티티를 데이터베이스 엔티티 목록에 추가 이 변경은 채팅 기능을 데이터베이스와 통합하기 위함입니다.**
