### PR TITLE
Diary 비즈니스 로직 구현

### DIFF
--- a/src/diary/diary.gateway.ts
+++ b/src/diary/diary.gateway.ts
@@ -1,7 +1,46 @@
-import { WebSocketGateway } from '@nestjs/websockets';
+import {
+  MessageBody,
+  OnGatewayConnection,
+  SubscribeMessage,
+  WebSocketGateway,
+} from '@nestjs/websockets';
 import { DiaryService } from './diary.service';
+import { ExecutionContext, UseGuards } from '@nestjs/common';
+import { GetUserEmail } from 'src/common/decorator/get-user';
+import { Socket } from 'socket.io';
+import { WsJwtGuard } from 'src/common/guard/ws-jwt-guard';
 
 @WebSocketGateway()
-export class DiaryGateway {
-  constructor(private readonly diaryService: DiaryService) {}
+@UseGuards(WsJwtGuard)
+@WebSocketGateway()
+export class DiaryGateway implements OnGatewayConnection {
+  constructor(
+    private readonly diaryService: DiaryService,
+    private readonly wsJwtGuard: WsJwtGuard,
+  ) {}
+
+  async handleConnection(client: Socket) {
+    try {
+      const createWsExecutionContext = () => {
+        return {
+          switchToWs: () => ({
+            getClient: () => client,
+          }),
+          getHandler: () => this.handleConnection,
+        } as unknown as ExecutionContext;
+      };
+
+      await this.wsJwtGuard.canActivate(createWsExecutionContext());
+      const userEmail = client.data.user.email;
+
+      this.diaryService.getDiary(userEmail, client);
+    } catch (error) {
+      client.disconnect();
+    }
+  }
+
+  @SubscribeMessage('setDiary')
+  setDiary(@GetUserEmail() userEmail: string, @MessageBody() data: string) {
+    this.diaryService.setDiary(userEmail, data);
+  }
 }

--- a/src/diary/diary.module.ts
+++ b/src/diary/diary.module.ts
@@ -3,10 +3,14 @@ import { DiaryService } from './diary.service';
 import { DiaryGateway } from './diary.gateway';
 import { RedisModule } from '@nestjs-modules/ioredis';
 import { ConfigService } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from 'src/user/entity/user.entity';
 import { EnvKeys } from 'src/common/enum/env-keys';
+import { WsJwtGuard } from 'src/common/guard/ws-jwt-guard';
 
 @Module({
   imports: [
+    TypeOrmModule.forFeature([User]),
     RedisModule.forRootAsync({
       inject: [ConfigService],
       useFactory: (config: ConfigService) => ({
@@ -18,6 +22,6 @@ import { EnvKeys } from 'src/common/enum/env-keys';
       }),
     }),
   ],
-  providers: [DiaryGateway, DiaryService],
+  providers: [WsJwtGuard, DiaryGateway, DiaryService],
 })
 export class DiaryModule {}

--- a/src/diary/diary.service.ts
+++ b/src/diary/diary.service.ts
@@ -1,6 +1,7 @@
 import { InjectRedis } from '@nestjs-modules/ioredis';
 import { Injectable } from '@nestjs/common';
 import Redis from 'ioredis';
+import { Socket } from 'socket.io';
 
 @Injectable()
 export class DiaryService {
@@ -8,4 +9,12 @@ export class DiaryService {
     @InjectRedis()
     private readonly redisClient: Redis,
   ) {}
+
+  async getDiary(userEmail: string, client: Socket) {
+    client.emit('diary', await this.redisClient.get(userEmail));
+  }
+
+  async setDiary(userEmail: string, data: string) {
+    await this.redisClient.set(userEmail, data);
+  }
 }


### PR DESCRIPTION
- **feat(diary.service.ts): 다이어리 서비스에 소켓을 통한 데이터 전송 기능 추가 다이어리 데이터를 소켓 클라이언트에 전송하고 저장하는 메서드 추가**
- **feat(diary.gateway.ts): WebSocket 연결 및 인증 기능 추가 WebSocket 연결 시 JWT 인증을 적용하여 보안을 강화하고 일기 설정 기능을 추가함.**
- **feat(diary.module.ts): TypeOrmModule과 User 엔티티 추가 feat(diary.module.ts): WsJwtGuard를 providers에 추가**
