### PR TITLE
generateToday함수로 한국 시간으로 createdAt설정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
         "bcrypt": "^5.1.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
+        "date-fns": "^4.1.0",
+        "date-fns-tz": "^3.2.0",
         "ioredis": "^5.6.0",
         "joi": "^17.13.3",
         "mysql2": "^3.14.0",
@@ -5091,6 +5093,25 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/dayjs": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "bcrypt": "^5.1.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "date-fns": "^4.1.0",
+    "date-fns-tz": "^3.2.0",
     "ioredis": "^5.6.0",
     "joi": "^17.13.3",
     "mysql2": "^3.14.0",

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -6,12 +6,12 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { User } from 'src/user/entity/user.entity';
 import { Repository } from 'typeorm';
 import { UserAlreadyExistsException } from 'src/exception/custom-exception/user-already-exists.exception.ts';
-import { ROLE } from 'src/common/enum/role';
 import * as bcrypt from 'bcrypt';
 import { TokensResponse } from './dto/response/tokens.response';
 import { EnvKeys } from 'src/common/enum/env-keys';
 import { LoginRequest } from './dto/request/login.reqeust';
 import { LoginFailException } from 'src/exception/custom-exception/login-fail.exception';
+import { generateToday } from 'src/common/util/generate-today';
 
 @Injectable()
 export class AuthService {
@@ -55,6 +55,7 @@ export class AuthService {
       email,
       password: await bcrypt.hash(password, 10),
       nickname,
+      createdAt: generateToday(),
     });
     await this.userRepository.save(newUser);
 

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -12,6 +12,7 @@ import { WellPromiseRequest } from './dto/request/well-promise.request';
 import { Promise } from 'src/promise/entity/promise.entity';
 import { PromiseNotFoundException } from 'src/exception/ws-custom-exception/promise-not-found.exception';
 import { SaveChatErrorException } from 'src/exception/ws-custom-exception/save-chat-error.exception';
+import { generateToday } from 'src/common/util/generate-today';
 
 @Injectable()
 export class ChatService {
@@ -81,11 +82,13 @@ export class ChatService {
         promise,
         content: '약속을 더 쉽게 지키는 법',
         role: ROLE.USER,
+        createdAt: generateToday(),
       });
       await this.chatRepository.save({
         promise,
         content: fullResponse,
         role: ROLE.SYSTEM,
+        createdAt: generateToday(),
       });
     } catch (error) {
       throw new SaveChatErrorException();

--- a/src/chat/entity/chat.entity.ts
+++ b/src/chat/entity/chat.entity.ts
@@ -2,7 +2,6 @@ import { ROLE } from 'src/common/enum/role';
 import { Promise } from 'src/promise/entity/promise.entity';
 import {
   Column,
-  CreateDateColumn,
   Entity,
   Index,
   ManyToOne,
@@ -31,6 +30,6 @@ export class Chat {
   })
   content: string;
 
-  @CreateDateColumn()
+  @Column({ nullable: false })
   createdAt: Date;
 }

--- a/src/common/util/generate-today.ts
+++ b/src/common/util/generate-today.ts
@@ -1,0 +1,7 @@
+import { formatInTimeZone } from 'date-fns-tz';
+
+export const generateToday = () => {
+  const timeZone = 'Asia/Seoul';
+  const formattedDate = formatInTimeZone(new Date(), timeZone, 'yyyy-MM-dd');
+  return formattedDate;
+};

--- a/src/promise/entity/promise.entity.ts
+++ b/src/promise/entity/promise.entity.ts
@@ -1,7 +1,13 @@
 import { Chat } from 'src/chat/entity/chat.entity';
 import { PromiseState } from 'src/common/enum/promise-state';
 import { User } from 'src/user/entity/user.entity';
-import { Column, CreateDateColumn, Entity, Index, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 
 @Entity('promise')
 export class Promise {
@@ -27,6 +33,6 @@ export class Promise {
   @OneToMany(() => Chat, (chat) => chat.promise)
   chates: Chat;
 
-  @CreateDateColumn({ type: "timestamp" })
+  @Column({ nullable: false })
   createdAt: Date;
 }

--- a/src/promise/promise.service.ts
+++ b/src/promise/promise.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Promise } from './entity/promise.entity';
-import { DataSource, EntityManager, Repository } from 'typeorm';
+import { EntityManager, Repository } from 'typeorm';
 import { CreatePromiseRequest } from './dto/request/create-promise.request';
 import { User } from 'src/user/entity/user.entity';
 import { UserNotFoundException } from 'src/exception/custom-exception/user-not-found.exception';
@@ -13,16 +13,13 @@ import { PromiseState } from 'src/common/enum/promise-state';
 import { ChangePromiseStateRequest } from './dto/request/change-promise-state.request';
 import { GetPromisesResponse } from './dto/response/get-promises.response';
 import { GetPromiseBodyRequest } from './dto/request/get-promise-body.request';
+import { generateToday } from 'src/common/util/generate-today';
 
 @Injectable()
 export class PromiseService {
   constructor(
     @InjectRepository(Promise)
     private readonly promiseRepository: Repository<Promise>,
-    @InjectRepository(User)
-    private readonly userRepository: Repository<User>,
-
-    private readonly datasource: DataSource,
   ) {}
 
   async createPromise(
@@ -41,6 +38,7 @@ export class PromiseService {
       title,
       dayOfWeek: dayOfWeek.length === 0 ? null : dayOfWeek.toString(),
       user,
+      createdAt: generateToday(),
     });
 
     return true;
@@ -70,11 +68,9 @@ export class PromiseService {
         });
       }
 
-      query.orderBy('p.createdAt', 'DESC')
+      query.orderBy('p.createdAt', 'DESC');
 
-      return new GetPromisesResponse(
-        await query.getMany()
-      );
+      return new GetPromisesResponse(await query.getMany());
     } catch (error) {
       throw new ServerException();
     }

--- a/src/user/entity/user.entity.ts
+++ b/src/user/entity/user.entity.ts
@@ -40,7 +40,9 @@ export class User {
   })
   withdrawDate: Date;
 
-  @CreateDateColumn()
+  @Column({
+    nullable: false
+  })
   createdAt: Date;
 
   @OneToMany(() => Promise, (promise) => promise.user)


### PR DESCRIPTION
- **feat(generate-today.ts): 오늘 날짜를 생성하는 유틸리티 함수 추가 오늘 날짜를 서울 시간대에 맞춰 포맷팅하는 기능을 구현.**
- **feat(package.json): date-fns 및 date-fns-tz 패키지 추가 날짜 및 시간 관련 기능을 개선하기 위해 새로운 라이브러리를 추가함.**
- **feat(auth, chat, promise, user): createdAt 필드를 추가하여 생성일 기록 기능(auth, chat, promise, user): 생성일을 기록하기 위해 createdAt 필드를 추가하여 데이터베이스에 저장하도록 변경**
