### PR TITLE
Promise DayOfWeek Set Type으로 수정

### DIFF
--- a/src/common/interface/promise.interface.ts
+++ b/src/common/interface/promise.interface.ts
@@ -2,7 +2,7 @@ import { PromiseState } from '../enum/promise-state';
 
 export interface Promise {
   title: string;
-  dayOfWeek: number[];
+  dayOfWeek: string;
   promiseState: PromiseState;
   createdAt: Date;
 }

--- a/src/common/set/day-of-weeks.ts
+++ b/src/common/set/day-of-weeks.ts
@@ -1,0 +1,1 @@
+export const dayOfWeeks = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];

--- a/src/promise/dto/request/create-promise.request.ts
+++ b/src/promise/dto/request/create-promise.request.ts
@@ -1,5 +1,5 @@
-import { Transform } from 'class-transformer';
-import { IsNotEmpty, IsNumber, IsString, Max, Min } from 'class-validator';
+import { IsIn, IsNotEmpty, IsString } from 'class-validator';
+import { dayOfWeeks } from 'src/common/set/day-of-weeks';
 
 export class CreatePromiseRequest {
   @IsNotEmpty({ message: '약속의 이름을 지어주세요' })
@@ -7,9 +7,6 @@ export class CreatePromiseRequest {
   title: string;
 
   @IsNotEmpty({ message: '날짜 형식을 지정해주세요' })
-  @IsNumber({}, { each: true, message: 'List는 숫자로만 이루어져야 합니다.' })
-  @Min(0, { each: true, message: '0~6 내외의 숫자만을 리스트에 넣어주세요' })
-  @Max(6, { each: true, message: '0~6 내외의 숫자만을 리스트에 넣어주세요' })
-  @Transform(({ value }) => value.sort())
-  dayOfWeek: number[];
+  @IsIn(dayOfWeeks, { each: true })
+  dayOfWeek: string[];
 }

--- a/src/promise/dto/request/get-promise-body.request.ts
+++ b/src/promise/dto/request/get-promise-body.request.ts
@@ -1,9 +1,10 @@
-import { IsNotEmpty, IsOptional, Max, Min } from 'class-validator';
+import { IsIn, IsNotEmpty, IsOptional, Max, Min } from 'class-validator';
+import { dayOfWeeks } from 'src/common/set/day-of-weeks';
 
 export class GetPromiseBodyRequest {
   @IsNotEmpty()
   @IsOptional()
-  @Min(0, { each: true, message: '0~6 내외의 숫자만을 리스트에 넣어주세요' })
-  @Max(6, { each: true, message: '0~6 내외의 숫자만을 리스트에 넣어주세요' })
-  dayOfWeek?: number[];
+  @IsNotEmpty({ message: '날짜 형식을 지정해주세요' })
+  @IsIn(dayOfWeeks, { each: true })
+  dayOfWeek?: string[];
 }

--- a/src/promise/dto/response/get-promises.response.ts
+++ b/src/promise/dto/response/get-promises.response.ts
@@ -7,10 +7,9 @@ export class GetPromisesResponse {
   constructor(promises: PromiseEntity[]) {
     this.promises = promises.map((value) => {
       return {
+        id: value.id,
         title: value.title,
-        dayOfWeek: value.dayOfWeek
-          ? value.dayOfWeek.split(',').map((value) => Number(value))
-          : null,
+        dayOfWeek: value.dayOfWeek,
         promiseState: value.promiseState,
         createdAt: value.createdAt,
       };

--- a/src/promise/entity/promise.entity.ts
+++ b/src/promise/entity/promise.entity.ts
@@ -1,4 +1,5 @@
 import { Chat } from 'src/chat/entity/chat.entity';
+import { dayOfWeeks } from 'src/common/set/day-of-weeks';
 import { PromiseState } from 'src/common/enum/promise-state';
 import { User } from 'src/user/entity/user.entity';
 import {
@@ -17,7 +18,7 @@ export class Promise {
   @Column({ nullable: false })
   title: string;
 
-  @Column({ comment: 'Number Array를 String으로 저장', nullable: true })
+  @Column({ type: 'set', enum: dayOfWeeks, nullable: false })
   dayOfWeek: string;
 
   @Column({

--- a/src/promise/promise.service.ts
+++ b/src/promise/promise.service.ts
@@ -36,7 +36,7 @@ export class PromiseService {
 
     await entityManager.save(Promise, {
       title,
-      dayOfWeek: dayOfWeek.length === 0 ? null : dayOfWeek.toString(),
+      dayOfWeek: dayOfWeek.join(','),
       user,
       createdAt: generateToday(),
     });
@@ -62,7 +62,7 @@ export class PromiseService {
 
       if (dayOfWeek) {
         dayOfWeek.forEach((day, index) => {
-          query.andWhere(`FIND_IN_SET(:day, p.dayOfWeek)`, {
+          query.andWhere(`find_in_set(:day, p.dayOfWeek)`, {
             day,
           });
         });
@@ -89,7 +89,7 @@ export class PromiseService {
       { id: promiseId, user: { email: userEmail } },
       {
         title,
-        dayOfWeek: dayOfWeek ? dayOfWeek.toString() : undefined,
+        dayOfWeek: dayOfWeek.join(','),
       },
     );
 


### PR DESCRIPTION
- **fix(promise.entity.ts): dayOfWeek 필드의 데이터 타입을 수정 dayOfWeek 필드를 String에서 'set' 타입으로 변경하여 유효한 요일 값만 저장하도록 개선**
- **feat(dto): 약속 요청 및 응답 DTO에서 요일 형식 변경 약속 요청에서 요일을 숫자 배열에서 문자열 배열로 변경하여 유효성 검사를 개선하고, 응답에서 요일 형식을 수정하여 일관성을 유지한다.**
- **fix(promise.service.ts): dayOfWeek 처리 방식을 배열에서 문자열로 변경 dayOfWeek를 join(',')으로 변환하여 데이터베이스 저장 및 쿼리 일관성 유지**
- **fix(interface): dayOfWeek 타입을 배열에서 문자열로 변경 feat(day-of-weeks): 요일 상수를 추가하여 가독성 향상**
