### PR TITLE
Calender 저장 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/mapped-types": "*",
         "@nestjs/platform-express": "^11.0.12",
         "@nestjs/platform-socket.io": "^11.0.12",
+        "@nestjs/schedule": "^5.0.1",
         "@nestjs/typeorm": "^11.0.0",
         "@nestjs/websockets": "^11.0.12",
         "bcrypt": "^5.1.1",
@@ -2639,6 +2640,19 @@
         "rxjs": "^7.1.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-5.0.1.tgz",
+      "integrity": "sha512-kFoel84I4RyS2LNPH6yHYTKxB16tb3auAEciFuc788C3ph6nABkUfzX5IE+unjVaRX+3GuruJwurNepMlHXpQg==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "3.5.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.2.tgz",
@@ -3210,6 +3224,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
+      "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==",
+      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -5080,6 +5100,16 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/cron": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-3.5.0.tgz",
+      "integrity": "sha512-0eYZqCnapmxYcV06uktql93wNWdlTmmBFP2iYz+JPVcQqlyFYcn1lFuIk4R54pkOmE7mcldTAPZv6X5XA4Q46A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.4.0",
+        "luxon": "~3.5.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -8337,6 +8367,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^11.0.12",
     "@nestjs/platform-socket.io": "^11.0.12",
+    "@nestjs/schedule": "^5.0.1",
     "@nestjs/typeorm": "^11.0.0",
     "@nestjs/websockets": "^11.0.12",
     "bcrypt": "^5.1.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,6 +16,7 @@ import { Chat } from './chat/entity/chat.entity';
 import { DiaryModule } from './diary/diary.module';
 import { CalenderModule } from './calender/calender.module';
 import { Calender } from './calender/entity/calender.entity';
+import { SuccessPromise } from './calender/entity/success-promise.entity';
 
 @Module({
   imports: [
@@ -44,7 +45,7 @@ import { Calender } from './calender/entity/calender.entity';
         username: configService.get(EnvKeys.DB_USERNAME),
         password: configService.get(EnvKeys.DB_PASSWORD),
         database: configService.get(EnvKeys.DB_DATABASE),
-        entities: [User, Promise, Chat, Calender],
+        entities: [User, Promise, Chat, Calender, SuccessPromise],
         synchronize: true,
       }),
     }),

--- a/src/calender/calender.module.ts
+++ b/src/calender/calender.module.ts
@@ -1,8 +1,18 @@
 import { Module } from '@nestjs/common';
 import { CalenderService } from './calender.service';
 import { CalenderController } from './calender.controller';
+import { ScheduleModule } from '@nestjs/schedule';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SuccessPromise } from './entity/success-promise.entity';
+import { Calender } from './entity/calender.entity';
+import { Promise } from 'src/promise/entity/promise.entity';
+import { User } from 'src/user/entity/user.entity';
 
 @Module({
+  imports: [
+    ScheduleModule.forRoot(),
+    TypeOrmModule.forFeature([Promise, SuccessPromise, Calender, User]),
+  ],
   controllers: [CalenderController],
   providers: [CalenderService],
 })

--- a/src/calender/calender.service.ts
+++ b/src/calender/calender.service.ts
@@ -1,4 +1,77 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Promise as PromiseEntity } from 'src/promise/entity/promise.entity';
+import { In, Repository } from 'typeorm';
+import { SuccessPromise } from './entity/success-promise.entity';
+import { Calender } from './entity/calender.entity';
+import { PromiseState } from 'src/common/enum/promise-state';
+import { generateToday } from 'src/common/util/generate-today';
+import { User } from 'src/user/entity/user.entity';
+import { dayOfWeeks } from 'src/common/set/day-of-weeks';
+import { Cron, CronExpression } from '@nestjs/schedule';
 
 @Injectable()
-export class CalenderService {}
+export class CalenderService {
+  constructor(
+    @InjectRepository(PromiseEntity)
+    private readonly promiseRepository: Repository<PromiseEntity>,
+    @InjectRepository(SuccessPromise)
+    private readonly successPromiseRepository: Repository<SuccessPromise>,
+    @InjectRepository(Calender)
+    private readonly calenderRepository: Repository<Calender>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async saveCalender() {
+    const completePromisesUsers = await this.promiseRepository
+      .createQueryBuilder('p')
+      .select('DISTINCT p.userEmail', 'userEmail')
+      .where('p.promiseState = :state', {
+        state: PromiseState.Completed.toString(),
+      })
+      .andWhere('find_in_set(:day, p.dayOfWeek)', {
+        day: dayOfWeeks[new Date(generateToday()).getDay()],
+      })
+      .getRawMany();
+
+    const userEmails = completePromisesUsers.map((u) => u.userEmail);
+    if (userEmails.length === 0) return [];
+
+    const users = await this.userRepository.find({
+      where: { email: In(userEmails) },
+    });
+    const userMap = new Map(users.map((user) => [user.email, user]));
+
+    for (const userEmail of userEmails) {
+      const user = userMap.get(userEmail);
+      if (!user) continue;
+
+      const calender = await this.calenderRepository.save({
+        diary: null,
+        date: generateToday(),
+        user,
+      });
+
+      const completedPromises = await this.promiseRepository
+        .createQueryBuilder('p')
+        .select('p.title', 'title')
+        .where('p.userEmail = :userEmail', { userEmail })
+        .andWhere('p.promiseState = :state', {
+          state: PromiseState.Completed.toString(),
+        })
+        .andWhere('find_in_set(:day, p.dayOfWeek)', {
+          day: dayOfWeeks[new Date(generateToday()).getDay()],
+        })
+        .getRawMany();
+
+      await Promise.all(completedPromises.map(({ title }) => {
+        this.successPromiseRepository.save({
+          title,
+          calender,
+        });
+      }));
+    }
+  }
+}

--- a/src/calender/entity/calender.entity.ts
+++ b/src/calender/entity/calender.entity.ts
@@ -1,5 +1,12 @@
 import { User } from 'src/user/entity/user.entity';
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { SuccessPromise } from './success-promise.entity';
 
 @Entity('calender')
 export class Calender {
@@ -19,4 +26,7 @@ export class Calender {
 
   @ManyToOne(() => User, (user) => user.calenders)
   user: User;
+
+  @OneToMany(() => SuccessPromise, (successPromise) => successPromise.calender)
+  successPromises: SuccessPromise[];
 }

--- a/src/calender/entity/success-promise.entity.ts
+++ b/src/calender/entity/success-promise.entity.ts
@@ -1,0 +1,14 @@
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Calender } from './calender.entity';
+
+@Entity('success_promise')
+export class SuccessPromise {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ nullable: false })
+  title: string;
+
+  @ManyToOne(() => Calender, (calender) => calender.successPromises)
+  calender: Calender;
+}


### PR DESCRIPTION
- **feat(calender): 성공 약속 엔티티 추가 및 캘린더와의 관계 설정 feat(calender): 캘린더 엔티티에 성공 약속과의 일대다 관계 추가**
- **feat(package.json): @nestjs/schedule 패키지를 추가 nestjs 스케줄링 기능을 사용하기 위해 의존성을 추가함.**
- **feat(calender): 캘린더 모듈에 스케줄링 및 데이터베이스 기능 추가 캘린더 서비스에 매일 자정에 실행되는 캘린더 저장 기능 추가**
- **feat(app.module.ts): SuccessPromise 엔티티를 모듈에 추가 이 변경은 데이터베이스 엔티티 목록에 SuccessPromise을 포함하여 애플리케이션의 기능을 확장하기 위함입니다.**
