### PR TITLE
saveCalender 기능에 트랜젝션 추가

### DIFF
--- a/src/calender/calender.controller.ts
+++ b/src/calender/calender.controller.ts
@@ -1,7 +1,15 @@
-import { Controller } from '@nestjs/common';
+import { Controller, UseInterceptors } from '@nestjs/common';
 import { CalenderService } from './calender.service';
+import { TransactionInterceptor } from 'src/common/interceptor/transaction.interceptor';
+import { GetEntityManager } from 'src/common/decorator/get-query-runner';
+import { EntityManager } from 'typeorm';
 
 @Controller('calender')
 export class CalenderController {
   constructor(private readonly calenderService: CalenderService) {}
+
+  @UseInterceptors(TransactionInterceptor)
+  async getCalender(@GetEntityManager() qr: EntityManager) {
+    return this.calenderService.saveCalender(qr);
+  }
 }

--- a/src/calender/calender.service.ts
+++ b/src/calender/calender.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Promise as PromiseEntity } from 'src/promise/entity/promise.entity';
-import { In, Repository } from 'typeorm';
+import { EntityManager, In, Repository } from 'typeorm';
 import { SuccessPromise } from './entity/success-promise.entity';
 import { Calender } from './entity/calender.entity';
 import { PromiseState } from 'src/common/enum/promise-state';
@@ -24,7 +24,7 @@ export class CalenderService {
   ) {}
 
   @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
-  async saveCalender() {
+  async saveCalender(qr: EntityManager) {
     const completePromisesUsers = await this.promiseRepository
       .createQueryBuilder('p')
       .select('DISTINCT p.userEmail', 'userEmail')
@@ -48,14 +48,14 @@ export class CalenderService {
       const user = userMap.get(userEmail);
       if (!user) continue;
 
-      const calender = await this.calenderRepository.save({
+      const calender = await qr.save(Calender, {
         diary: null,
         date: generateToday(),
         user,
       });
 
-      const completedPromises = await this.promiseRepository
-        .createQueryBuilder('p')
+      const completedPromises = await qr
+        .createQueryBuilder(PromiseEntity, 'p')
         .select('p.title', 'title')
         .where('p.userEmail = :userEmail', { userEmail })
         .andWhere('p.promiseState = :state', {
@@ -66,12 +66,14 @@ export class CalenderService {
         })
         .getRawMany();
 
-      await Promise.all(completedPromises.map(({ title }) => {
-        this.successPromiseRepository.save({
-          title,
-          calender,
-        });
-      }));
+      await Promise.all(
+        completedPromises.map(({ title }) => {
+          this.successPromiseRepository.save({
+            title,
+            calender,
+          });
+        }),
+      );
     }
   }
 }


### PR DESCRIPTION
- **fix(calender.service.ts): saveCalender 메서드에 EntityManager 매개변수 추가 refactor(calender.service.ts): calenderRepository.save 및 createQueryBuilder 호출을 EntityManager로 변경**
- **feat(calender.controller.ts): 캘린더 컨트롤러에 트랜잭션 인터셉터 추가 추가된 메서드로 캘린더를 저장하는 기능을 구현**
